### PR TITLE
Register anonymous plugins without extension

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -2,6 +2,7 @@
 
 namespace Afbora;
 
+use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
@@ -55,12 +56,20 @@ class Loader
             return false;
         }
 
+        $dirname = basename($root);
+
         $entry = $root . DIRECTORY_SEPARATOR . 'index.php';
-        if (is_dir($root) === false || is_file($entry) === false) {
+        $script = $root . DIRECTORY_SEPARATOR . 'index.js';
+        $styles = $root . DIRECTORY_SEPARATOR . 'index.css';
+
+        if (is_dir($root) === true && is_file($entry) === true) {
+            F::loadOnce($entry, false);
+        } elseif (is_file($script) === true || is_file($styles) === true) {
+            App::plugin('plugins/' . $dirname, ['root' => $root]);
+        } else {
             return false;
         }
 
-        F::loadOnce($entry);
 
         return true;
     }


### PR DESCRIPTION
Hi Ahmet,

thanks for this plugin. I am currently experimenting with improving our personal starter kit; I would like to separate third-party plugins from first-party plugins that I only wrote for this specific project. Bnomei made me aware of your plugin in Discord and it looks like it already brings me halfway there. 

However I realized your plugin loader is not up-to-date with what the Kirby core does. I added the missing pieces so that it also loads plugins that to not have any extensions (i.e. no `index.php`) but a custom `index.js` or `index.css`. 

Code is shamelessly [copied from Kirby core ](https://github.com/getkirby/kirby/blob/2965c3124e3b141072a2d46c798a327dda710060/src/Cms/AppPlugins.php#L779-L793)and adjusted accordingly. 

Let me know what you think 👍 